### PR TITLE
Make run

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     git clone https://github.com/stonedefi/stoneindex-node.git
     make init
     make build
-    cargo run -- --dev
+    make run
     ```
 
     or run with docker:


### PR DESCRIPTION
The combination of make build (cargo build --release) and cargo run -- --dev doesn’t make a lot of sense. You have to use make run, otherwise the front-end doesn’t connect to the back-end.